### PR TITLE
Allow transfer to be overriden.

### DIFF
--- a/src/contracts/tokens/nf-token.sol
+++ b/src/contracts/tokens/nf-token.sol
@@ -305,6 +305,7 @@ contract NFToken is
     uint256 _tokenId
   )
     internal
+    virtual
   {
     address from = idToOwner[_tokenId];
     _clearApproval(_tokenId);


### PR DESCRIPTION
This will enable contract to override internal `_transfer` function in case you want to create a non transferable nft token or add some other features to it. 